### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 **Disclaimer** - This is a WIP version of the plugin. 
 
-##Installation.
+## Installation.
 1. [Download the plugin files](https://raw.githubusercontent.com/saleiva/sketch-charts/master/Barchart/Generate%20Barchart.sketchplugin)
 2. Double-click the '.sketchplugin' file you want to install. Sketch should open automatically and tell you that a new plugin was installed.
 
-##Usage
+## Usage
 
 #### Barcharts.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
